### PR TITLE
Add ability to send a slack message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .terraform
 terraform-provider-slack
+terraform.tfstate*
+crash.log

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,3 +1,7 @@
-resource "slack" "slack" {
-    hook_url = "https://api.slack.com"
+provider "slack" {
+  webhook_url = var.webhook_url
+}
+
+resource "slack_message" "message" {
+  message = "Terraform slack provider"
 }

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,0 +1,4 @@
+variable "webhook_url" {
+  type        = string
+  description = "Webhook url for the app as described in https://api.slack.com/incoming-webhooks"
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/caulagi/terraform-provider-slack
 
 go 1.13
 
-require github.com/hashicorp/terraform-plugin-sdk v1.1.1
+require (
+	github.com/hashicorp/terraform-plugin-sdk v1.1.1
+	github.com/nlopes/slack v0.6.0
+)

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
+github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -147,12 +149,16 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/nlopes/slack v0.6.0 h1:jt0jxVQGhssx1Ib7naAOZEZcGdtIhTzkP0nopK0AsRA=
+github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/slack/provider.go
+++ b/slack/provider.go
@@ -6,8 +6,17 @@ import (
 
 func Provider() *schema.Provider {
 	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"webhook_url": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SLACK_WEBHOOK_URL", nil),
+				Description: "Webhook url for slack app as in https://api.slack.com/incoming-webhooks",
+			},
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
-			"slack": resourceServer(),
+			"slack_message": resourceServer(),
 		},
 	}
 }

--- a/slack/resource_slack_message.go
+++ b/slack/resource_slack_message.go
@@ -1,26 +1,38 @@
 package slack
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/nlopes/slack"
 )
 
 func resourceServer() *schema.Resource {
+	log.Printf("[INFO] Creating Sentry organization %s", "params.Name")
 	return &schema.Resource{
 		Create: resourceServerCreate,
 		Read:   resourceServerRead,
 		Update: resourceServerUpdate,
 		Delete: resourceServerDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
-			"hook_url": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+			"message": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The human readable name for the organization",
 			},
 		},
 	}
 }
 
 func resourceServerCreate(d *schema.ResourceData, m interface{}) error {
+	message := d.Get("message").(string)
+	d.SetId(message)
+	sendMessage(message)
 	return resourceServerRead(d, m)
 }
 
@@ -33,5 +45,21 @@ func resourceServerUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceServerDelete(d *schema.ResourceData, m interface{}) error {
+	return nil
+}
+
+func sendMessage(message string) error {
+	attachment := slack.Attachment{
+		Color: "good",
+		Text:  message,
+	}
+	msg := slack.WebhookMessage{
+		Attachments: []slack.Attachment{attachment},
+	}
+
+	err := slack.PostWebhook("FIXME", &msg)
+	if err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
The webhook url is not being read from the provider and needs to be added in the code, for this to work, but the rest looks ok. The workflow would be

```bash
$ go build
$ cd example
$ terraform init -plugin-dir ..
$ terraform plan -var webhook_url=<fixme>
$ terraform apply -var webhook_url=<fixme>
```