### PR TITLE
Use webhook from provider in slack resource

### DIFF
--- a/slack/provider.go
+++ b/slack/provider.go
@@ -4,6 +4,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+type Config struct {
+	webhookURL string
+}
+
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
@@ -18,5 +22,13 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"slack_message": resourceServer(),
 		},
+
+		ConfigureFunc: configureProvider,
 	}
+}
+
+func configureProvider(d *schema.ResourceData) (interface{}, error) {
+	return Config{
+		webhookURL: d.Get("webhook_url").(string),
+	}, nil
 }

--- a/slack/resource_slack_message.go
+++ b/slack/resource_slack_message.go
@@ -1,9 +1,9 @@
 package slack
 
 import (
-	"log"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/nlopes/slack"
+	"log"
 )
 
 func resourceServer() *schema.Resource {


### PR DESCRIPTION
The provider is configured with the webhook to use for all requests to slack. Use that in the terraform slack resource to send message.