### PR TITLE
Set terraform state for resource after successful response

### DIFF
--- a/slack/provider.go
+++ b/slack/provider.go
@@ -20,7 +20,7 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"slack_message": resourceServer(),
+			"slack_message": slackMessage(),
 		},
 
 		ConfigureFunc: configureProvider,

--- a/slack/resource_slack_message.go
+++ b/slack/resource_slack_message.go
@@ -6,12 +6,12 @@ import (
 	"log"
 )
 
-func resourceServer() *schema.Resource {
+func slackMessage() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceServerCreate,
-		Read:   resourceServerRead,
-		Update: resourceServerUpdate,
-		Delete: resourceServerDelete,
+		Create: slackMessageCreate,
+		Read:   slackMessageRead,
+		Update: slackMessageUpdate,
+		Delete: slackMessageDelete,
 
 		Importer: nil,
 
@@ -25,26 +25,26 @@ func resourceServer() *schema.Resource {
 	}
 }
 
-func resourceServerCreate(d *schema.ResourceData, m interface{}) error {
-	config := m.(Config)
+func slackMessageCreate(d *schema.ResourceData, m interface{}) error {
 	message := d.Get("message").(string)
-	d.SetId(message)
-	err := sendMessage(message, config.webhookURL)
+	err := sendMessage(message, m.(Config).webhookURL)
 	if err != nil {
-		return resourceServerRead(d, m)
+
+		return err
 	}
-	return err
+	d.SetId(message)
+	return slackMessageRead(d, m)
 }
 
-func resourceServerRead(d *schema.ResourceData, m interface{}) error {
+func slackMessageRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func resourceServerUpdate(d *schema.ResourceData, m interface{}) error {
-	return resourceServerRead(d, m)
+func slackMessageUpdate(d *schema.ResourceData, m interface{}) error {
+	return slackMessageRead(d, m)
 }
 
-func resourceServerDelete(d *schema.ResourceData, m interface{}) error {
+func slackMessageDelete(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 


### PR DESCRIPTION
Set the terraform state for the slack resource only after we get a 'successful[1]' response. Also rename the methods to more closely match intent.

[1] - Need to add more checks, like checking 200 responses with 'ok' is true